### PR TITLE
working for both in&out and old maintenance page up on regular landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,8 @@ Now, you can start the service by running:
 To check the status of service, run:
 `sudo systemctl status uwsgi`
 
-nginx.conf
+from /etc/nginx/nginx.conf
 ```
-# from /etc/nginx/nginx.conf
 # For more information on configuration, see:
 #   * Official English Documentation: http://nginx.org/en/docs/
 #   * Official Russian Documentation: http://nginx.org/ru/docs/
@@ -103,10 +102,13 @@ http {
         include /etc/nginx/default.d/*.conf;
 
 	location / {
-	    include uwsgi_params;
-	    uwsgi_pass 127.0.0.1:8080;
+            proxy_pass http://127.0.0.1:8081;
 	}
-
+	location /spfy {
+	    rewrite ^/spfy(.*) /$1 break;
+            include uwsgi_params;
+            uwsgi_pass 127.0.0.1:8080;
+        }
 
 
     }
@@ -139,6 +141,8 @@ http {
         }
 
     }
+
+
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,10 +107,6 @@ http {
 	    uwsgi_pass 127.0.0.1:8080;
 	}
 
-	location /superphy {
-	    include uwsgi_params;
-	    uwsgi_pass 127.0.0.1:8080;
-	}
 
 
     }
@@ -125,22 +121,25 @@ http {
         # Load configuration files for the default server block.
         include /etc/nginx/default.d/*.conf;
 
-        location / {
-            include uwsgi_params;
-            uwsgi_pass 127.0.0.1:8080;
-        }
+	location / {
+            proxy_pass http://127.0.0.1:8081;
+	}
         location /superphy {
+            proxy_pass https://127.0.0.1:8081;
+        }
+	location /superphy/spfy {
+	    rewrite ^/superphy/spfy(.*) /$1 break;
             include uwsgi_params;
             uwsgi_pass 127.0.0.1:8080;
         }
-
+	location /spfy {
+	    rewrite ^/spfy(.*) /$1 break;
+            include uwsgi_params;
+            uwsgi_pass 127.0.0.1:8080;
+        }
 
     }
-
-
-
 }
-
 ```
 
 perms for nginx uploads

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ http {
         listen       [::]:80 default_server;
 	listen       [::]:443 ssl http2 default_server;
 	server_name  superphy.corefacility.ca;
-	server_name  lfz.corefacility.ca/superphy;
         # Load configuration files for the default server block.
         include /etc/nginx/default.d/*.conf;
 
@@ -107,17 +106,40 @@ http {
 	    include uwsgi_params;
 	    uwsgi_pass 127.0.0.1:8080;
 	}
+
 	location /superphy {
 	    include uwsgi_params;
 	    uwsgi_pass 127.0.0.1:8080;
 	}
+
+
+    }
+
+    server {
+        client_max_body_size 200m;
+        listen       80;
+        listen       443 ssl http2;
+        listen       [::]:80;
+        listen       [::]:443 ssl http2;
+        server_name  lfz.corefacility.ca;
+        # Load configuration files for the default server block.
+        include /etc/nginx/default.d/*.conf;
+
+        location / {
+            include uwsgi_params;
+            uwsgi_pass 127.0.0.1:8080;
+        }
+        location /superphy {
+            include uwsgi_params;
+            uwsgi_pass 127.0.0.1:8080;
+        }
+
 
     }
 
 
 
 }
-
 
 ```
 


### PR DESCRIPTION
🎅 🎄 ☃️ 🎁 🎋 🌋 
http://superphy.corefacility.ca/spfy/ and http://superphy.corefacility.ca/
for intranet
and
https://lfz.corefacility.ca/superphy/spfy/ and https://lfz.corefacility.ca/superphy/
for ex
its a little weird tat you need the `/` at the end of `spfy`