### PR TITLE
MERGE: fixes to polling job status

### DIFF
--- a/app/modules/spfy.py
+++ b/app/modules/spfy.py
@@ -165,7 +165,7 @@ def spfy(args_dict):
     # abs path resolution should be handled in spfy.py
     #args_dict['i'] = os.path.abspath(args_dict['i'])
 
-    print 'Starting blob_savvy call'
+    #print 'Starting blob_savvy call'
     jobs_dict = blob_savvy(args_dict)
 
     return jobs_dict

--- a/app/routes/job_utils.py
+++ b/app/routes/job_utils.py
@@ -1,4 +1,5 @@
 import redis
+import config
 from flask import current_app
 from rq import Queue
 
@@ -8,7 +9,7 @@ from rq import Queue
 # out the number of possible connections
 
 
-def fetch_job(job_id, redis_connection=redis.from_url(current_app.config['REDIS_URL'])):
+def fetch_job(job_id, redis_connection=redis.from_url(config['REDIS_URL'])):
     '''
     Iterates through all queues looking for the job.
     '''

--- a/app/routes/job_utils.py
+++ b/app/routes/job_utils.py
@@ -9,10 +9,12 @@ from rq import Queue
 # out the number of possible connections
 
 
-def fetch_job(job_id, redis_connection=redis.from_url(config['REDIS_URL'])):
+def fetch_job(job_id, redis_connection=None):
     '''
     Iterates through all queues looking for the job.
     '''
+    if not redis_connection:
+        redis_connection = redis.from_url(current_app.config['REDIS_URL'])
     queues = current_app.config['QUEUES_SPFY']
     for queue in queues:
         q = Queue(queue, connection=redis_connection)

--- a/app/routes/job_utils.py
+++ b/app/routes/job_utils.py
@@ -2,12 +2,16 @@ import redis
 from flask import current_app
 from rq import Queue
 
-def fetch_job(job_id):
+# ideally, functions that call fetch_job() multiple times should create
+# their own redis_connection and pass it as a param. otherwise, we have to
+# create a new connection every time in that loop which can quickly max
+# out the number of possible connections
+
+
+def fetch_job(job_id, redis_connection=redis.from_url(current_app.config['REDIS_URL'])):
     '''
     Iterates through all queues looking for the job.
     '''
-    redis_url = current_app.config['REDIS_URL']
-    redis_connection = redis.from_url(redis_url)
     queues = current_app.config['QUEUES_SPFY']
     for queue in queues:
         q = Queue(queue, connection=redis_connection)
@@ -17,12 +21,14 @@ def fetch_job(job_id):
     print 'fetch_job(): ERROR ' + job_id + ' not found'
     return Job(is_failed=True, exc_info='job not found')
 
+
 class Job(object):
     '''
     A class to mimick the Job object returned by RQ's Queue.fetch_job()
     We use this to create custom Jobs with our own error messages.
     This allows custom error messages to be parsed by the same code.
     '''
+
     def __init__(self, is_finished=False, result='', is_failed=False, exc_info=''):
         self.is_finished = is_finished
         self.result = result

--- a/app/routes/job_utils.py
+++ b/app/routes/job_utils.py
@@ -1,5 +1,4 @@
 import redis
-import config
 from flask import current_app
 from rq import Queue
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1091,7 +1091,7 @@ To monitor the status of RQ tasks and check on failed jobs, you have two options
 
 We recommend using ``RQ-dashboard`` to see jobs being enqueued live when testing as ``Sentry`` only reports failed jobs. On remote deployments, we use ``Sentry`` for error reporting.
 
-..warning:: ``RQ-dashboard`` will not report errors from the Flask webserver. In addition, jobs enqueued with ``depends_on`` will not appear on the queues list until their dependencies are complete.
+.. warning:: ``RQ-dashboard`` will not report errors from the Flask webserver. In addition, jobs enqueued with ``depends_on`` will not appear on the queues list until their dependencies are complete.
 
 Debugging Javascript
 --------------------

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1091,7 +1091,7 @@ To monitor the status of RQ tasks and check on failed jobs, you have two options
 
 We recommend using ``RQ-dashboard`` to see jobs being enqueued live when testing as ``Sentry`` only reports failed jobs. On remote deployments, we use ``Sentry`` for error reporting.
 
-Note: ``RQ-dashboard`` will not report errors from the Flask webserver.
+..warning:: ``RQ-dashboard`` will not report errors from the Flask webserver. In addition, jobs enqueued with ``depends_on`` will not appear on the queues list until their dependencies are complete.
 
 Debugging Javascript
 --------------------


### PR DESCRIPTION
Was previously establishing a new redis_connection per rq job id in a grouped `blob` id. Now uses the same redis_connection per front-end request.